### PR TITLE
Introduce binary command dispatcher for OTA protocol

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,9 @@ default_envs = basic_server
 upload_protocol = custom
 upload_speed = -1
 extra_scripts =
-upload_command = ~/.platformio/penv/bin/python -u $PROJECT_DIR/scripts/dfu-ble-uploader.py -d e20e664a4716aba3abc6b9a0329b5b2e --log-level debug  --chunk 512 $SOURCE
+; Pass device via: PLATFORMIO_UPLOAD_FLAGS="-d ADDRESS" pio run -e ota_server -t upload
+; Or by name:      PLATFORMIO_UPLOAD_FLAGS="-n DeviceName" pio run -e ota_server -t upload
+upload_command = ~/.platformio/penv/bin/python -u $PROJECT_DIR/scripts/dfu-ble-uploader.py $UPLOAD_FLAGS --log-level debug --chunk 512 $SOURCE
 
 [esptool_upload]
 upload_protocol = esptool
@@ -49,8 +51,6 @@ build_flags =
     -Wl,-O3                  ; Optimize during linking
 
 [env]
-upload = ${serial_upload}
-
 upload_protocol = ${upload.upload_protocol}
 upload_speed = ${upload.upload_speed}
 upload_command = ${upload.upload_command}
@@ -101,7 +101,11 @@ build_unflags =
 
 ; Serial monitor settings
 monitor_speed = 115200
-monitor_filters = esp32_exception_decoder
+monitor_filters =
+    esp32_exception_decoder
+    colorize
+    time
+
 
 ; Library dependencies (pinned to exact versions for production stability)
 lib_deps =

--- a/scripts/dfu-ble-uploader.py
+++ b/scripts/dfu-ble-uploader.py
@@ -832,8 +832,8 @@ async def run_upload_with_args(args: argparse.Namespace) -> int:
     uploader_logger.setLevel(level)
     logging.getLogger("dfu_cli").setLevel(level)
 
-    device_address = args.device or os.environ.get("BLE_DEVICE_ADDRESS")
-    device_name = args.name
+    device_address = (args.device or os.environ.get("BLE_DEVICE_ADDRESS") or "").strip() or None
+    device_name = (args.name or "").strip() or None
 
     if not device_address and not device_name:
         logger.error("Device required (address or name).")


### PR DESCRIPTION
  - Add blex_binary_command.hpp for opcode-based binary typed command handling
  - Zero heap allocation, compile-time validation, fold-based dispatch
  - Refactor OTA service to use binary command flow
  - Add OTA session ownership with dynamic connection speed management
  - Add connection parameter API (update/restore) across Server/Service/Characteristic
  - Add WithOnMTUChange, WithOnConnParamsUpdate server callbacks
  - Update docs and README with binary command dispatcher usage