### PR TITLE
refactor(binary_command): optimize dispatch and fix sizeof(void) warning

### DIFF
--- a/include/blex/binary_command.hpp
+++ b/include/blex/binary_command.hpp
@@ -55,6 +55,13 @@ private:
          std::is_standard_layout_v<Payload> &&      // predictable wire format
          has_one_byte_alignment<Payload>::value);       // no padding (#pragma pack(1))
 
+    /// @brief Helper to get sizeof(T) without triggering sizeof(void) warning
+    template<typename T, typename = void>
+    struct sizeof_or_zero : std::integral_constant<size_t, sizeof(T)> {};
+
+    template<typename T>
+    struct sizeof_or_zero<T, std::enable_if_t<std::is_void_v<T>>> : std::integral_constant<size_t, 0> {};
+
     /// @brief Bool trait - has a message interface (SFINAE, no errors)
     template<typename, typename = void>
     struct has_message_like_interface : std::false_type {};
@@ -92,8 +99,7 @@ private:
 
         static constexpr uint8_t opcode = static_cast<uint8_t>(Opcode);
         using payload_type = Payload;
-        static constexpr size_t payload_size =
-            std::is_void_v<Payload> ? 0 : sizeof(Payload);
+        static constexpr size_t payload_size = sizeof_or_zero<Payload>::value;
     };
 
 public:


### PR DESCRIPTION
  - Skip policy validate() call for SizeExact<> (N=0) - dispatcher validates directly against sizeof(payload_type)
  - Fix sizeof(void) warning using SFINAE partial specialization for SizeofOrZero helper
  - Remove redundant typename keywords in reinterpret_cast expressions
  - Wrap OTA timing variables in #if BLEX_LOG_LEVEL >= BLEX_LOG_LEVEL_DEBUG to eliminate unused variable warnings in production builds